### PR TITLE
Code Sample doesn't work with os.getenv for CONNECTION_STRING

### DIFF
--- a/iot-hub/Quickstarts/simulated-device-2/SimulatedDeviceSync.py
+++ b/iot-hub/Quickstarts/simulated-device-2/SimulatedDeviceSync.py
@@ -9,7 +9,7 @@ from azure.iot.device import IoTHubDeviceClient, Message, MethodResponse
 # The device connection string to authenticate the device with your IoT hub.
 # Using the Azure CLI:
 # az iot hub device-identity show-connection-string --hub-name {YourIoTHubName} --device-id MyNodeDevice --output table
-CONNECTION_STRING = os.getenv("IOTHUB_DEVICE_CONNECTION_STRING")
+CONNECTION_STRING = ("IOTHUB_DEVICE_CONNECTION_STRING")
 
 # Define the JSON message to send to IoT Hub.
 TEMPERATURE = 20.0


### PR DESCRIPTION
Code Sample doesn't work with os.getenv for CONNECTION_STRING when running python SimulatedDeviceSync.py command. 
As per this doc: https://learn.microsoft.com/en-us/azure/iot-hub/quickstart-control-device?pivots=programming-language-python#simulate-a-device

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->